### PR TITLE
Automate Art19 episode creation using LLM-generated title and shownote (draft save only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          
+      - name: Verify dependencies
+        run: go mod verify
+        
+      - name: Build
+        run: go build -v ./...
+        
+      - name: Run tests
+        run: go test -v ./...
+        
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout=5m

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,35 @@
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          
+      - name: Verify dependencies
+        run: go mod verify
+        
+      - name: Build
+        run: go build -v ./...
+        
+      - name: Run tests
+        run: go test -v ./...
+        
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout=5m

--- a/README.md
+++ b/README.md
@@ -1,83 +1,76 @@
 # AIPodFlow
 
-AIPodFlow is an open-source CLI tool that leverages AI to streamline podcast production workflow, from transcript processing to content generation and publishing. It automates the generation of titles, show notes, and ad placement suggestions based on podcast transcripts.
-
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![CI Status](https://github.com/fuzzy31u/aipodflow/workflows/CI/badge.svg)](https://github.com/fuzzy31u/aipodflow/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/fuzzy31u/aipodflow)](https://goreportcard.com/report/github.com/fuzzy31u/aipodflow)
 
-## Features
+AIPodFlow is an open-source CLI tool that leverages AI to streamline podcast production workflow. It automates the entire process from transcript processing to content generation and publishing, making podcast production faster and more efficient.
 
-- **Transcript Processing**: Process podcast transcripts to extract key information
+## 🚀 Features
+
 - **AI-powered Content Generation**: 
-  - Generate engaging title candidates
-  - Create comprehensive show notes based on transcript content
-  - Suggest optimal ad placement timecodes
-- **Interactive & Non-interactive Modes**: Choose content interactively or automatically
-- **Automated Publishing**: Seamless integration with various podcast hosting platforms
-- **Vercel Integration**: Automate website updates when new episodes are published
-- **Social Media Support**: Generate content for Twitter/X posts
+  - Generate engaging title candidates based on transcript content
+  - Create comprehensive show notes with proper formatting and emojis
+  - Suggest optimal ad placement timecodes for monetization
+- **Interactive Selection**: Choose the best content from multiple AI-generated candidates
+- **Non-interactive Mode**: Automatically select content for batch processing
+- **Art19 Integration**: Seamlessly upload content to Art19 podcast hosting platform
+- **Complete LLM Content**: Ensures all LLM-generated content is preserved without omissions
 
-## Installation
+## 📋 Requirements
 
-### Prerequisites
-
-- Go 1.18 or higher
+- Go 1.21 or higher
 - OpenAI API key
-- Podcast platform credentials (optional, for publishing)
+- Art19 credentials (optional, for publishing)
+
+## 🔧 Installation
 
 ### From Source
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/aipodflow.git
+git clone https://github.com/fuzzy31u/aipodflow.git
 cd aipodflow
 
 # Install dependencies
 go mod download
 
 # Build the binary
-go build -o aipodflow ./cmd/podcast-cli
+go build -o podcast-cli ./cmd/podcast-cli
 ```
 
-## Configuration
+## ⚙️ Configuration
 
-Create a `.env` file in the project root with your API credentials:
+Create a `config.yaml` file in the project root or in `$HOME/.aipodflow/` directory:
 
-```env
-# OpenAI API Configuration
-OPENAI_API_KEY=your_openai_key
+```yaml
+# OpenAI API Configuration (required)
+openai_api_key: "your_openai_api_key"
 
-# Podcast Platform Configuration (optional)
-# For Art19:
-ART19_USERNAME=your_art19_username
-ART19_PASSWORD=your_art19_password
-# Other platforms can be added in the future
-
-# Twitter API Configuration (optional)
-TWITTER_API_KEY=your_twitter_key
-TWITTER_API_SECRET=your_twitter_secret
-TWITTER_ACCESS_TOKEN=your_access_token
-TWITTER_ACCESS_SECRET=your_access_secret
-
-# Vercel Configuration (optional)
-VERCEL_DEPLOY_HOOK=your_vercel_hook_url
+# Art19 Configuration (optional, for publishing)
+art19_username: "your_art19_username"
+art19_password: "your_art19_password"
 ```
 
-## Usage
+## 🖥️ Usage
 
 ### Process a Transcript
 
 ```bash
-# Interactive mode
-./aipodflow process-transcript --input-transcript /path/to/transcript.txt
+# Interactive mode (default)
+./podcast-cli process-transcript --input-transcript /path/to/transcript.txt
 
 # Non-interactive mode (auto-selects first candidates)
-./aipodflow process-transcript --input-transcript /path/to/transcript.txt --non-interactive
+./podcast-cli process-transcript --input-transcript /path/to/transcript.txt --non-interactive
 
-# Specify output directory
-./aipodflow process-transcript --input-transcript /path/to/transcript.txt --output-dir ./output
+# Specify output directory for generated content
+./podcast-cli process-transcript --input-transcript /path/to/transcript.txt --output-dir ./output
 
-# Include audio file for podcast platform upload
-./aipodflow process-transcript --input-transcript /path/to/transcript.txt --input-audio /path/to/audio.mp3
+# Include audio file for Art19 upload
+./podcast-cli process-transcript --input-transcript /path/to/transcript.txt --input-audio /path/to/audio.mp3
+
+# Enable verbose logging
+./podcast-cli process-transcript --input-transcript /path/to/transcript.txt --verbose
 ```
 
 ### Command Options
@@ -88,23 +81,40 @@ Usage:
 
 Flags:
   -h, --help                      help for process-transcript
-  -a, --input-audio string        Path to audio file (required for podcast platform upload)
+  -a, --input-audio string        Path to audio file (for Art19 upload)
   -t, --input-transcript string   Path to transcript file (required)
   -n, --non-interactive           Run in non-interactive mode (auto-select first candidates)
   -o, --output-dir string         Output directory for generated files
   -v, --verbose                   Enable verbose logging
 ```
 
-## Architecture
+## 🏗️ Architecture
 
-AIPodFlow is built using Go and implements a CLI tool for controlling the podcast production pipeline. It integrates with various services:
+AIPodFlow is built with a modular architecture:
 
-- OpenAI API for content generation
-- Various podcast hosting platforms (Art19, Spotify, etc.)
-- Vercel for website deployment
-- Twitter/X API for social media distribution
+- **CLI Layer**: Handles user input and command execution
+- **Processor Layer**: Manages the content generation workflow
+- **Service Layer**: Integrates with external APIs (OpenAI, Art19)
+- **UI Layer**: Provides interactive selection interface
+- **Model Layer**: Defines data structures for content processing
 
-## Contributing
+### Key Components
+
+- **OpenAI Integration**: Uses GPT-4o for high-quality content generation
+- **Art19 API**: Enables direct upload of podcast content
+- **Interactive UI**: Terminal-based interface for content selection
+
+## 🧪 Development
+
+The project uses:
+
+- Go 1.21+
+- Cobra for CLI commands
+- Logrus for structured logging
+- Viper for configuration management
+- GitHub Actions for CI/CD
+
+## 🤝 Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
@@ -114,21 +124,6 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
-## License
+## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-- `GET /api/v1/status/:id` - Check pipeline status
-- `GET /health` - Health check endpoint
-
-## Development
-
-The project uses:
-
-- Go 1.21+
-- Gin for HTTP routing
-- Logrus for logging
-- Godotenv for environment management
-
-## License
-
-MIT


### PR DESCRIPTION
## 概要
- Art19エピソード新規作成をPlaywrightで自動化
- タイトル・ShowNote（説明）を外部ファイル（scripts/episode_title_and_shownote.txt）から抽出し、入力・ドラフト保存まで自動化
- テスト用JSは削除し、本番用スクリプト（art19_create_episode.js）のみ残しています

## 詳細
- GoやLLMで生成したタイトル・ShowNoteをoutput→scripts/episode_title_and_shownote.txtにコピーして利用
- Description欄はWYSIWYGエディタ対応
- テストやデバッグ用コードは含めていません

ご確認ください。