### PR TITLE
Implement step-by-step execution workflow for podcast processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ AIPodFlow is an open-source CLI tool that leverages AI to streamline podcast pro
   - Generate engaging title candidates based on transcript content
   - Create comprehensive show notes with proper formatting and emojis
   - Suggest optimal ad placement timecodes for monetization
+- **Step-by-Step Workflow**: Execute each step of the podcast production process separately
+  - Step 1: Process transcript and generate content with OpenAI
+  - Step 2: Upload title, show notes, and audio to Art19
+  - Step 3: Redeploy website on Vercel (coming soon)
+  - Step 4: Create and post content to X (coming soon)
 - **Interactive Selection**: Choose the best content from multiple AI-generated candidates
 - **Non-interactive Mode**: Automatically select content for batch processing
 - **Art19 Integration**: Seamlessly upload content to Art19 podcast hosting platform
@@ -59,23 +64,40 @@ art19_password: "your_art19_password"
 
 ## 🖥️ Usage
 
-### Process a Transcript
+### Process a Podcast (Step by Step)
+
+AIPodFlow now supports executing each step of the podcast processing workflow separately, giving you more control over the process:
+
+```bash
+# Step 1: Process transcript and call OpenAI API
+./podcast-cli process step1 --input-transcript /path/to/transcript.txt --output-dir ./output
+
+# Step 2: Upload title, shownote and audio to Art19
+./podcast-cli process step2 --input-audio /path/to/audio.mp3 --content-file ./output/selected_content.txt
+
+# Step 3: Redeploy website on Vercel (not fully implemented yet)
+./podcast-cli process step3
+
+# Step 4: Create text to post to X (not fully implemented yet)
+./podcast-cli process step4
+```
+
+### Process a Transcript (Legacy Mode)
+
+You can still use the legacy mode to process everything in a single command:
 
 ```bash
 # Interactive mode (default)
-./podcast-cli process-transcript --input-transcript /path/to/transcript.txt
-
-# Non-interactive mode (auto-selects first candidates)
-./podcast-cli process-transcript --input-transcript /path/to/transcript.txt --non-interactive
+./podcast-cli process all --input-transcript /path/to/transcript.txt
 
 # Specify output directory for generated content
-./podcast-cli process-transcript --input-transcript /path/to/transcript.txt --output-dir ./output
+./podcast-cli process all --input-transcript /path/to/transcript.txt --output-dir ./output
 
 # Include audio file for Art19 upload
-./podcast-cli process-transcript --input-transcript /path/to/transcript.txt --input-audio /path/to/audio.mp3
+./podcast-cli process all --input-transcript /path/to/transcript.txt --input-audio /path/to/audio.mp3
 
 # Enable verbose logging
-./podcast-cli process-transcript --input-transcript /path/to/transcript.txt --verbose
+./podcast-cli process all --input-transcript /path/to/transcript.txt --verbose
 ```
 
 ### Upload to Art19 with PlayWright MCP
@@ -97,16 +119,50 @@ This script will launch a browser, log in to Art19, and upload your episode auto
 
 ### Command Options
 
+#### Step 1: Process Transcript and Call OpenAI API
+
 ```
 Usage:
-  podcast-cli process-transcript [flags]
+  podcast-cli process step1 [flags]
 
 Flags:
-  -h, --help                      help for process-transcript
-  -a, --input-audio string        Path to audio file (for Art19 upload)
+      --gen-shownotes             Generate show notes (default: true)
+  -h, --help                      help for step1
   -t, --input-transcript string   Path to transcript file (required)
-  -n, --non-interactive           Run in non-interactive mode (auto-select first candidates)
+      --openai-key string         OpenAI API key (can also be set via OPENAI_API_KEY environment variable)
   -o, --output-dir string         Output directory for generated files
+      --titles-only               Generate only titles, skip show notes
+  -v, --verbose                   Enable verbose logging
+```
+
+#### Step 2: Upload to Art19
+
+```
+Usage:
+  podcast-cli process step2 [flags]
+
+Flags:
+  -c, --content-file string      Path to content file with title and show notes (required)
+  -h, --help                     help for step2
+  -a, --input-audio string       Path to audio file (required)
+  -v, --verbose                  Enable verbose logging
+```
+
+#### Legacy Mode (All Steps)
+
+```
+Usage:
+  podcast-cli process all [flags]
+
+Flags:
+      --api-only                  Stop after API call and display response
+      --gen-shownotes             Generate show notes (default: true)
+  -h, --help                      help for all
+  -a, --input-audio string        Path to audio file (required)
+  -t, --input-transcript string   Path to transcript file (required)
+  -o, --output-dir string         Output directory for generated files
+      --skip-upload               Skip uploading to Art19
+      --titles-only               Generate only titles, skip show notes
   -v, --verbose                   Enable verbose logging
 ```
 

--- a/internal/cli/process.go
+++ b/internal/cli/process.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -113,19 +112,4 @@ func NewLegacyProcessCmd() *cobra.Command {
 	return processCmd
 }
 
-// sanitizeFilename replaces characters that cannot be used in filenames
-func sanitizeFilename(filename string) string {
-	// Replace characters that cannot be used in filenames
-	replacer := strings.NewReplacer(
-		"/", "_",
-		"\\", "_",
-		":", "_",
-		"*", "_",
-		"?", "_",
-		"\"", "_",
-		"<", "_",
-		">", "_",
-		"|", "_",
-	)
-	return replacer.Replace(filename)
-}
+// Note: sanitizeFilename function has been moved to the processor package

--- a/internal/cli/process.go
+++ b/internal/cli/process.go
@@ -6,17 +6,31 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/automate-podcast/config"
-	"github.com/automate-podcast/internal/model"
-	"github.com/automate-podcast/internal/processor"
-	"github.com/automate-podcast/internal/ui"
-	"github.com/automate-podcast/services"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-// NewProcessCmd creates a command for transcript processing
+// NewProcessCmd creates a parent command for podcast processing with step subcommands
 func NewProcessCmd() *cobra.Command {
+	processCmd := &cobra.Command{
+		Use:   "process",
+		Short: "Process podcast content",
+		Long:  `Process podcast content with separate steps for transcript processing, Art19 upload, Vercel redeployment, and X posting.`,
+	}
+
+	// Add step subcommands
+	processCmd.AddCommand(Step1Cmd())
+	processCmd.AddCommand(Step2Cmd())
+	processCmd.AddCommand(Step3Cmd())
+	processCmd.AddCommand(Step4Cmd())
+	
+	// Add the legacy command for backward compatibility
+	processCmd.AddCommand(NewLegacyProcessCmd())
+
+	return processCmd
+}
+
+// NewLegacyProcessCmd creates the original process command for backward compatibility
+func NewLegacyProcessCmd() *cobra.Command {
 	var inputTranscript string
 	var inputAudio string
 	var outputDir string
@@ -27,133 +41,55 @@ func NewProcessCmd() *cobra.Command {
 	var apiOnly bool
 
 	processCmd := &cobra.Command{
-		Use:   "process-transcript",
-		Short: "Process podcast transcript",
-		Long:  `Process podcast transcript to generate show notes and upload to Art19.`,
+		Use:   "all",
+		Short: "Process podcast transcript (legacy mode)",
+		Long:  `Process podcast transcript to generate show notes and upload to Art19 in a single command.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Initialize logger
-			logger := logrus.New()
+			// Run step 1
+			step1Cmd := Step1Cmd()
+			step1Args := []string{
+				"--input-transcript", inputTranscript,
+				"--output-dir", outputDir,
+			}
 			if verbose {
-				logger.SetLevel(logrus.DebugLevel)
-			} else {
-				logger.SetLevel(logrus.InfoLevel)
+				step1Args = append(step1Args, "--verbose")
 			}
-			logger.SetFormatter(&logrus.TextFormatter{
-				FullTimestamp: true,
-			})
-
-			// Load configuration
-			cfg, err := config.LoadConfig()
-			if err != nil {
-				return fmt.Errorf("failed to load configuration: %w", err)
-			}
-
-			// Create output directory
-			if outputDir != "" {
-				if err := os.MkdirAll(outputDir, 0755); err != nil {
-					return fmt.Errorf("failed to create output directory: %w", err)
-				}
-			}
-
-			// 1. Load transcript
-			logger.Infof("Loading transcript from %s", inputTranscript)
-			transcript, err := processor.LoadTranscript(inputTranscript)
-			if err != nil {
-				return fmt.Errorf("failed to load transcript: %w", err)
-			}
-			logger.Info("Transcript loaded successfully")
-
-			// 2. Initialize services
-			aiService := services.NewAIService(cfg.OpenAIAPIKey, logger)
-			art19Service := services.NewArt19Service(cfg.Art19Username, cfg.Art19Password, logger)
-
-			// 3. Initialize processor
-			contentProcessor := processor.NewContentProcessor(aiService, logger)
-
-			// 4. AI generation process
-			logger.Info("Starting content generation...")
-			// Determine what to generate based on flags
-			genShownotes := generateShowNotes
-	
-			// If titles-only is set, override other flags
 			if titlesOnly {
-				genShownotes = false
+				step1Args = append(step1Args, "--titles-only")
 			}
-	
-			// Generate content
-			candidates, err := contentProcessor.GenerateCandidates(transcript, genShownotes)
-			if err != nil {
-				return fmt.Errorf("content generation failed: %w", err)
+			if !generateShowNotes {
+				step1Args = append(step1Args, "--gen-shownotes=false")
 			}
-			logger.Info("Content generation completed")
-
-			// 5. Selection process (always use our display-only UI)
-			var selectedContent *model.SelectedContent
-
-			// Use the interactive UI which now just displays the content without prompts
-			interactiveUI := ui.NewInteractiveUI(logger)
-			logger.Info("Displaying content...")
-			selectedContent, err = interactiveUI.SelectContent(candidates)
-			if err != nil {
-				return fmt.Errorf("content display failed: %w", err)
+			
+			step1Cmd.SetArgs(step1Args)
+			if err := step1Cmd.Execute(); err != nil {
+				return err
 			}
-
-			// Save all candidates to file if output directory is specified
-			if outputDir != "" {
-				allCandidatesPath := filepath.Join(outputDir, "all_candidates.txt")
-				content := "=== Title Candidates ===\n"
-				for i, title := range candidates.Titles {
-					content += fmt.Sprintf("%d: %s\n", i+1, title)
-				}
-
-				content += "\n=== Show Note Candidates ===\n"
-				for i, note := range candidates.ShowNotes {
-					content += fmt.Sprintf("%d:\n%s\n\n", i+1, note)
-				}
-
-				if err := os.WriteFile(allCandidatesPath, []byte(content), 0644); err != nil {
-					logger.Warnf("Failed to save all candidates to file: %v", err)
-				} else {
-					logger.Infof("All candidates saved to %s", allCandidatesPath)
-				}
-			}
-			logger.Info("Content display completed")
-
+			
 			// Exit early if api-only flag is set
 			if apiOnly {
-				logger.Info("API-only mode: stopping after API call as requested")
 				return nil
 			}
-
-			// 6. Save selection (optional)
-			if outputDir != "" {
-				// Use title as filename
-				sanitizedTitle := sanitizeFilename(selectedContent.Title)
-				outputPath := filepath.Join(outputDir, sanitizedTitle+".txt")
-
-				// Save content
-				content := fmt.Sprintf("=== Selected Content ===\nTitle: %s\n\nShow Notes:\n%s",
-					selectedContent.Title, selectedContent.ShowNote)
-
-				if err := os.WriteFile(outputPath, []byte(content), 0644); err != nil {
-					logger.Warnf("Failed to save selection to file: %v", err)
-				} else {
-					logger.Infof("Selection saved to %s", outputPath)
+			
+			// Skip Art19 upload if requested
+			if !skipUpload && inputAudio != "" {
+				// Run step 2
+				selectedPath := filepath.Join(outputDir, "selected_content.txt")
+				step2Cmd := Step2Cmd()
+				step2Args := []string{
+					"--input-audio", inputAudio,
+					"--content-file", selectedPath,
+				}
+				if verbose {
+					step2Args = append(step2Args, "--verbose")
+				}
+				
+				step2Cmd.SetArgs(step2Args)
+				if err := step2Cmd.Execute(); err != nil {
+					return err
 				}
 			}
-
-			// 7. Art19 upload (optional)
-			if !skipUpload {
-				art19Processor := processor.NewArt19Processor(art19Service, logger)
-				logger.Info("Starting Art19 upload process...")
-				if err := art19Processor.UploadDraft(cmd.Context(), inputAudio, selectedContent); err != nil {
-					return fmt.Errorf("Art19 upload failed: %w", err)
-				}
-			} else {
-				logger.Info("Skipping Art19 upload as requested")
-			}
-
-			logger.Info("Process completed successfully!")
+			
 			return nil
 		},
 	}

--- a/internal/cli/steps.go
+++ b/internal/cli/steps.go
@@ -1,0 +1,306 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/automate-podcast/config"
+	"github.com/automate-podcast/internal/model"
+	"github.com/automate-podcast/internal/processor"
+	"github.com/automate-podcast/internal/ui"
+	"github.com/automate-podcast/services"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// Step1Cmd creates a command for transcript processing and OpenAI API call
+func Step1Cmd() *cobra.Command {
+	var inputTranscript string
+	var outputDir string
+	var verbose bool
+	var titlesOnly bool
+	var generateShowNotes bool
+	var openAIKey string
+
+	cmd := &cobra.Command{
+		Use:   "step1",
+		Short: "Process transcript and call OpenAI API",
+		Long:  `Import the transcript file, call OpenAI API, and show the output in console.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Initialize logger
+			logger := logrus.New()
+			if verbose {
+				logger.SetLevel(logrus.DebugLevel)
+			} else {
+				logger.SetLevel(logrus.InfoLevel)
+			}
+			logger.SetFormatter(&logrus.TextFormatter{
+				FullTimestamp: true,
+			})
+
+			// Get OpenAI API key from flag or environment
+			if openAIKey == "" {
+				openAIKey = os.Getenv("OPENAI_API_KEY")
+				if openAIKey == "" {
+					return fmt.Errorf("OpenAI API key is required. Set it with --openai-key flag or OPENAI_API_KEY environment variable")
+				}
+			}
+
+			// Create output directory if specified
+			if outputDir != "" {
+				if err := os.MkdirAll(outputDir, 0755); err != nil {
+					return fmt.Errorf("failed to create output directory: %w", err)
+				}
+			}
+
+			// 1. Load transcript
+			logger.Infof("Loading transcript from %s", inputTranscript)
+			transcript, err := processor.LoadTranscript(inputTranscript)
+			if err != nil {
+				return fmt.Errorf("failed to load transcript: %w", err)
+			}
+			logger.Info("Transcript loaded successfully")
+
+			// 2. Initialize AI service
+			aiService := services.NewAIService(openAIKey, logger)
+
+			// 3. Initialize processor
+			contentProcessor := processor.NewContentProcessor(aiService, logger)
+
+			// 4. AI generation process
+			logger.Info("Starting content generation...")
+			// Determine what to generate based on flags
+			genShownotes := generateShowNotes
+	
+			// If titles-only is set, override other flags
+			if titlesOnly {
+				genShownotes = false
+			}
+	
+			// Generate content
+			candidates, err := contentProcessor.GenerateCandidates(transcript, genShownotes)
+			if err != nil {
+				return fmt.Errorf("content generation failed: %w", err)
+			}
+			logger.Info("Content generation completed")
+
+			// 5. Display the generated content
+			interactiveUI := ui.NewInteractiveUI(logger)
+			logger.Info("Displaying content...")
+			selectedContent, err := interactiveUI.SelectContent(candidates)
+			if err != nil {
+				return fmt.Errorf("content display failed: %w", err)
+			}
+
+			// Save all candidates to file if output directory is specified
+			if outputDir != "" {
+				allCandidatesPath := filepath.Join(outputDir, "all_candidates.txt")
+				content := "=== Title Candidates ===\n"
+				for i, title := range candidates.Titles {
+					content += fmt.Sprintf("%d: %s\n", i+1, title)
+				}
+
+				content += "\n=== Show Note Candidates ===\n"
+				for i, note := range candidates.ShowNotes {
+					content += fmt.Sprintf("%d:\n%s\n\n", i+1, note)
+				}
+
+				if err := os.WriteFile(allCandidatesPath, []byte(content), 0644); err != nil {
+					logger.Warnf("Failed to save all candidates to file: %v", err)
+				} else {
+					logger.Infof("All candidates saved to %s", allCandidatesPath)
+				}
+				
+				// Also save the selected content
+				selectedPath := filepath.Join(outputDir, "selected_content.txt")
+				selectedContent := fmt.Sprintf("=== Selected Content ===\nTitle: %s\n\nShow Notes:\n%s",
+					selectedContent.Title, selectedContent.ShowNote)
+				
+				if err := os.WriteFile(selectedPath, []byte(selectedContent), 0644); err != nil {
+					logger.Warnf("Failed to save selected content to file: %v", err)
+				} else {
+					logger.Infof("Selected content saved to %s", selectedPath)
+				}
+			}
+
+			logger.Info("Step 1 completed successfully!")
+			return nil
+		},
+	}
+
+	// Set flags
+	cmd.Flags().StringVarP(&inputTranscript, "input-transcript", "t", "", "Path to transcript file (required)")
+	cmd.Flags().StringVarP(&outputDir, "output-dir", "o", "", "Output directory for generated files")
+	cmd.Flags().StringVar(&openAIKey, "openai-key", "", "OpenAI API key (can also be set via OPENAI_API_KEY environment variable)")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
+	cmd.Flags().BoolVar(&titlesOnly, "titles-only", false, "Generate only titles, skip show notes")
+	cmd.Flags().BoolVar(&generateShowNotes, "gen-shownotes", true, "Generate show notes (default: true)")
+
+	// Set required flags
+	if err := cmd.MarkFlagRequired("input-transcript"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error marking flag as required: %v\n", err)
+	}
+
+	return cmd
+}
+
+// Step2Cmd creates a command for uploading to Art19
+func Step2Cmd() *cobra.Command {
+	var inputAudio string
+	var contentFile string
+	var verbose bool
+
+	cmd := &cobra.Command{
+		Use:   "step2",
+		Short: "Upload to Art19",
+		Long:  `Upload title, shownote and audio to the Art19 platform.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Initialize logger
+			logger := logrus.New()
+			if verbose {
+				logger.SetLevel(logrus.DebugLevel)
+			} else {
+				logger.SetLevel(logrus.InfoLevel)
+			}
+			logger.SetFormatter(&logrus.TextFormatter{
+				FullTimestamp: true,
+			})
+
+			// Load configuration
+			cfg, err := config.LoadConfig()
+			if err != nil {
+				return fmt.Errorf("failed to load configuration: %w", err)
+			}
+
+			// Load selected content from file
+			var selectedContent *model.SelectedContent
+			if contentFile != "" {
+				// Read content from file
+				logger.Infof("Loading content from %s", contentFile)
+				content, err := os.ReadFile(contentFile)
+				if err != nil {
+					return fmt.Errorf("failed to read content file: %w", err)
+				}
+				
+				// Parse content
+				contentStr := string(content)
+				titleStart := strings.Index(contentStr, "Title: ")
+				showNotesStart := strings.Index(contentStr, "Show Notes:")
+				
+				if titleStart >= 0 && showNotesStart > titleStart {
+					title := strings.TrimSpace(contentStr[titleStart+len("Title: "):showNotesStart])
+					showNote := strings.TrimSpace(contentStr[showNotesStart+len("Show Notes:"):])
+					
+					selectedContent = &model.SelectedContent{
+						Title:    title,
+						ShowNote: showNote,
+					}
+				} else {
+					return fmt.Errorf("failed to parse content file, expected format not found")
+				}
+			} else {
+				return fmt.Errorf("content file is required")
+			}
+
+			// Initialize Art19 service
+			art19Service := services.NewArt19Service(cfg.Art19Username, cfg.Art19Password, logger)
+			art19Processor := processor.NewArt19Processor(art19Service, logger)
+			
+			// Upload to Art19
+			logger.Info("Starting Art19 upload process...")
+			if err := art19Processor.UploadDraft(cmd.Context(), inputAudio, selectedContent); err != nil {
+				return fmt.Errorf("Art19 upload failed: %w", err)
+			}
+
+			logger.Info("Step 2 completed successfully!")
+			return nil
+		},
+	}
+
+	// Set flags
+	cmd.Flags().StringVarP(&inputAudio, "input-audio", "a", "", "Path to audio file (required)")
+	cmd.Flags().StringVarP(&contentFile, "content-file", "c", "", "Path to content file (required)")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
+
+	// Set required flags
+	if err := cmd.MarkFlagRequired("input-audio"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error marking flag as required: %v\n", err)
+	}
+	if err := cmd.MarkFlagRequired("content-file"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error marking flag as required: %v\n", err)
+	}
+
+	return cmd
+}
+
+// Step3Cmd creates a command for redeploying on Vercel
+func Step3Cmd() *cobra.Command {
+	var verbose bool
+
+	cmd := &cobra.Command{
+		Use:   "step3",
+		Short: "Redeploy on Vercel",
+		Long:  `Call Redeploy button in the Vercel via API.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Initialize logger
+			logger := logrus.New()
+			if verbose {
+				logger.SetLevel(logrus.DebugLevel)
+			} else {
+				logger.SetLevel(logrus.InfoLevel)
+			}
+			logger.SetFormatter(&logrus.TextFormatter{
+				FullTimestamp: true,
+			})
+
+			// This feature is not implemented yet
+			logger.Info("Vercel redeployment feature is not implemented yet")
+			logger.Info("This will be implemented in a future update")
+
+			logger.Info("Step 3 completed successfully!")
+			return nil
+		},
+	}
+
+	// Set flags
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
+
+	return cmd
+}
+
+// Step4Cmd creates a command for posting to X
+func Step4Cmd() *cobra.Command {
+	var verbose bool
+
+	cmd := &cobra.Command{
+		Use:   "step4",
+		Short: "Post to X",
+		Long:  `Create the text to post to X.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Initialize logger
+			logger := logrus.New()
+			if verbose {
+				logger.SetLevel(logrus.DebugLevel)
+			} else {
+				logger.SetLevel(logrus.InfoLevel)
+			}
+			logger.SetFormatter(&logrus.TextFormatter{
+				FullTimestamp: true,
+			})
+
+			// This feature is not implemented yet
+			logger.Info("X posting feature is not implemented yet")
+			logger.Info("This will be implemented in a future update")
+
+			logger.Info("Step 4 completed successfully!")
+			return nil
+		},
+	}
+
+	// Set flags
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
+
+	return cmd
+}

--- a/internal/ui/interactive.go
+++ b/internal/ui/interactive.go
@@ -1,8 +1,6 @@
 package ui
 
 import (
-	"fmt"
-
 	"github.com/automate-podcast/internal/model"
 	"github.com/sirupsen/logrus"
 )
@@ -56,26 +54,7 @@ func (ui *InteractiveUI) SelectContent(candidates *model.ContentCandidates) (*mo
 	return selected, nil
 }
 
-// formatTitleOptions formats title candidates for display
-func formatTitleOptions(titles []string) []string {
-	options := make([]string, len(titles))
-	for i, title := range titles {
-		options[i] = fmt.Sprintf("%d: %s", i+1, title)
-	}
-	return options
-}
-
-// formatShowNoteOptions formats ShowNote candidates for display
-func formatShowNoteOptions(showNotes []string) []string {
-	options := make([]string, len(showNotes))
-	for i, note := range showNotes {
-		preview := note
-		if len(note) > 100 {
-			preview = note[:97] + "..."
-		}
-		options[i] = fmt.Sprintf("%d: %s", i+1, preview)
-	}
-	return options
-}
+// Note: These formatting functions have been removed as they are no longer used
+// in the current implementation of the interactive UI.
 
 // Ad timecode formatting removed


### PR DESCRIPTION
## Description
This PR implements a new feature that allows executing each step of the podcast processing workflow separately, giving users more control and flexibility in their podcast production process.

## Changes
- Created a new command structure with subcommands for each step:
  - `step1`: Process transcript and call OpenAI API
  - `step2`: Upload title, shownote and audio to Art19
  - `step3`: Redeploy website on Vercel (placeholder for future implementation)
  - `step4`: Create text to post to X (placeholder for future implementation)
- Refactored the existing process command to use these subcommands
- Added a legacy mode (`all`) for backward compatibility
- Updated README with documentation for the new command structure

## Testing
- Successfully tested the step1 command with a sample transcript
- Verified that the output files are created correctly
- Confirmed that the legacy mode works as expected

## Screenshots
N/A

## Related Issues
N/A