### PR TITLE
Implement Vercel redeployment functionality for step3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ AIPodFlow is an open-source CLI tool that leverages AI to streamline podcast pro
 - **Step-by-Step Workflow**: Execute each step of the podcast production process separately
   - Step 1: Process transcript and generate content with OpenAI
   - Step 2: Upload title, show notes, and audio to Art19
-  - Step 3: Redeploy website on Vercel (coming soon)
+  - Step 3: Redeploy website on Vercel
   - Step 4: Create and post content to X (coming soon)
 - **Interactive Selection**: Choose the best content from multiple AI-generated candidates
 - **Non-interactive Mode**: Automatically select content for batch processing
@@ -75,8 +75,9 @@ AIPodFlow now supports executing each step of the podcast processing workflow se
 # Step 2: Upload title, shownote and audio to Art19
 ./podcast-cli process step2 --input-audio /path/to/audio.mp3 --content-file ./output/selected_content.txt
 
-# Step 3: Redeploy website on Vercel (not fully implemented yet)
-./podcast-cli process step3
+# Step 3: Redeploy website on Vercel
+./podcast-cli process step3 --dry-run  # Validate configuration without triggering deployment
+./podcast-cli process step3            # Trigger actual redeployment
 
 # Step 4: Create text to post to X (not fully implemented yet)
 ./podcast-cli process step4
@@ -145,6 +146,18 @@ Flags:
   -c, --content-file string      Path to content file with title and show notes (required)
   -h, --help                     help for step2
   -a, --input-audio string       Path to audio file (required)
+  -v, --verbose                  Enable verbose logging
+```
+
+#### Step 3: Redeploy on Vercel
+
+```
+Usage:
+  podcast-cli process step3 [flags]
+
+Flags:
+      --dry-run                  Validate configuration without triggering actual redeployment
+  -h, --help                     help for step3
   -v, --verbose                  Enable verbose logging
 ```
 

--- a/services/vercel_service.go
+++ b/services/vercel_service.go
@@ -1,0 +1,90 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// VercelService is a service responsible for Vercel-related operations
+type VercelService struct {
+	deployHookURL string
+	client        *http.Client
+	logger        *logrus.Logger
+}
+
+// NewVercelService creates a new VercelService instance
+func NewVercelService(deployHookURL string, logger *logrus.Logger) *VercelService {
+	// Initialize HTTP client with timeout
+	client := &http.Client{
+		Timeout: time.Second * 30,
+	}
+
+	return &VercelService{
+		deployHookURL: deployHookURL,
+		client:        client,
+		logger:        logger,
+	}
+}
+
+// NewVercelServiceFromEnv creates a new VercelService instance using environment variables
+func NewVercelServiceFromEnv(logger *logrus.Logger) *VercelService {
+	// Get deploy hook URL from environment variable
+	deployHookURL := os.Getenv("VERCEL_DEPLOY_HOOK")
+
+	// Initialize HTTP client with timeout
+	client := &http.Client{
+		Timeout: time.Second * 30,
+	}
+
+	return &VercelService{
+		deployHookURL: deployHookURL,
+		client:        client,
+		logger:        logger,
+	}
+}
+
+// TriggerRedeploy triggers a redeployment of the website on Vercel
+func (s *VercelService) TriggerRedeploy(ctx context.Context) error {
+	if s.deployHookURL == "" {
+		return fmt.Errorf("Vercel deploy hook URL is not configured")
+	}
+
+	s.logger.Info("Triggering Vercel redeployment...")
+
+	// Create a POST request to the deploy hook URL
+	// Vercel deploy hooks expect an empty POST request with no body
+	req, err := http.NewRequestWithContext(ctx, "POST", s.deployHookURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set the Content-Type header to application/json
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send the request
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Log the response status for debugging
+	s.logger.Debugf("Vercel API response status: %s", resp.Status)
+
+	// Check the response status
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Read the response body for error details
+		body, _ := io.ReadAll(resp.Body)
+		s.logger.Debugf("Response body: %s", string(body))
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	s.logger.Info("Vercel redeployment triggered successfully")
+	return nil
+}


### PR DESCRIPTION
## Description
This PR implements the Vercel redeployment functionality for step3, allowing users to trigger a redeployment of their website on Vercel via API.

## Changes
- Created a new `VercelService` for interacting with the Vercel API
- Implemented the `TriggerRedeploy` method to make a POST request to the Vercel deploy hook URL
- Updated the `Step3Cmd` function to load environment variables from the .env file
- Added a `--dry-run` flag to validate configuration without triggering actual redeployment
- Updated the README with documentation for the Vercel redeployment feature

## Testing
- Successfully tested the feature with both dry-run and actual redeployment
- Verified that the Vercel API responds with a 201 Created status code, indicating success
- Confirmed that the website is redeployed with the latest content

## Screenshots
N/A

## Related Issues
N/A