### PR TITLE
Implement social media post generation for step4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,9 +15,9 @@ TWITTER_ACCESS_SECRET=your_twitter_access_secret
 VERCEL_DEPLOY_HOOK=https://api.vercel.com/v1/integrations/deploy/your_hook_id
 
 # Podcast URLs Configuration
-RSS_FEED_URL=https://rss.art19.com/momitfm
-SPOTIFY_SHOW_URL=https://open.spotify.com/show/5F2ppZb8gxJngLlO6wlIqX
-APPLE_PODCAST_URL=https://podcasts.apple.com/us/podcast/momit-fm/id1589345170
+RSS_FEED_URL=your_podcast_rss_feed_url
+SPOTIFY_SHOW_URL=your_spotify_show_url
+APPLE_PODCAST_URL=your_apple_podcast_url
 
 # Server Configuration
 PORT=8080

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@ TWITTER_ACCESS_SECRET=your_twitter_access_secret
 # Vercel Configuration
 VERCEL_DEPLOY_HOOK=https://api.vercel.com/v1/integrations/deploy/your_hook_id
 
+# Podcast URLs Configuration
+RSS_FEED_URL=https://rss.art19.com/momitfm
+SPOTIFY_SHOW_URL=https://open.spotify.com/show/5F2ppZb8gxJngLlO6wlIqX
+APPLE_PODCAST_URL=https://podcasts.apple.com/us/podcast/momit-fm/id1589345170
+
 # Server Configuration
 PORT=8080
-UPLOAD_DIR=uploads 
+UPLOAD_DIR=uploads

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AIPodFlow is an open-source CLI tool that leverages AI to streamline podcast pro
   - Step 1: Process transcript and generate content with OpenAI
   - Step 2: Upload title, show notes, and audio to Art19
   - Step 3: Redeploy website on Vercel
-  - Step 4: Create and post content to X (coming soon)
+  - Step 4: Generate social media post text from RSS feed data
 - **Interactive Selection**: Choose the best content from multiple AI-generated candidates
 - **Non-interactive Mode**: Automatically select content for batch processing
 - **Art19 Integration**: Seamlessly upload content to Art19 podcast hosting platform
@@ -161,6 +161,22 @@ Flags:
   -v, --verbose                  Enable verbose logging
 ```
 
+#### Step 4: Generate Social Media Post Text
+
+```
+Usage:
+  podcast-cli process step4 [flags]
+
+Flags:
+      --apple-url string        URL of the Apple Podcast show (can also be set via APPLE_PODCAST_URL environment variable)
+      --dry-run                 Validate configuration without making external requests
+  -h, --help                    help for step4
+      --output string           File to save the generated post text (optional)
+      --rss-url string          URL of the podcast RSS feed (can also be set via RSS_FEED_URL environment variable)
+      --spotify-url string      URL of the Spotify show (can also be set via SPOTIFY_SHOW_URL environment variable)
+  -v, --verbose                 Enable verbose logging
+```
+
 #### Legacy Mode (All Steps)
 
 ```
@@ -197,8 +213,35 @@ AIPodFlow is built with a modular architecture:
 
 - **CLI Layer**: Handles user input and command execution
 - **Processor Layer**: Manages the content generation workflow
-- **Service Layer**: Integrates with external APIs (OpenAI, Art19)
+- **Service Layer**: Integrates with external APIs (OpenAI, Art19, Vercel) and services (RSS feeds)
 - **UI Layer**: Provides interactive selection interface
+
+## 📱 Social Media Post Generation
+
+The Step4 command generates formatted text for posting to social media platforms about your podcast episodes:
+
+- **Automated Data Collection**: Fetches the latest episode title from your podcast's RSS feed
+- **Platform Links**: Includes links to your podcast on Spotify and Apple Podcasts
+- **Customizable Template**: Uses a predefined template with your podcast branding
+- **Environment Configuration**: Configure URLs via environment variables or command-line flags
+- **Output Options**: Display in console or save to a file for later use
+
+Example output:
+
+```
+IT企業で働くママによる子育て×Tech Podcast momit.fm を配信しました🎙 w/@m2vela
+—
+[Latest Episode Title]
+
+👇Spotify
+[Spotify URL]
+
+👇Apple
+[Apple Podcast URL]
+
+#momitfm #子育テック
+```
+
 - **Model Layer**: Defines data structures for content processing
 
 ### Integrations

--- a/internal/cli/steps.go
+++ b/internal/cli/steps.go
@@ -330,21 +330,39 @@ func Step4Cmd() *cobra.Command {
 				logger.Debug("Loaded environment variables from .env file")
 			}
 
-			// Set default values if not provided
+			// Set values from environment variables or command-line flags
 			if rssURL == "" {
-				rssURL = "https://rss.art19.com/momitfm"
-				logger.Infof("Using default RSS feed URL: %s", rssURL)
+				rssURL = os.Getenv("RSS_FEED_URL")
+				if rssURL == "" {
+					rssURL = "https://rss.art19.com/momitfm" // Fallback default
+					logger.Info("RSS_FEED_URL not set in environment, using default value")
+				} else {
+					logger.Infof("Using RSS feed URL from environment: %s", rssURL)
+				}
 			}
+			logger.Infof("RSS feed URL: %s", rssURL)
 
 			if spotifyShowURL == "" {
-				spotifyShowURL = "https://open.spotify.com/show/5F2ppZb8gxJngLlO6wlIqX"
-				logger.Infof("Using default Spotify show URL: %s", spotifyShowURL)
+				spotifyShowURL = os.Getenv("SPOTIFY_SHOW_URL")
+				if spotifyShowURL == "" {
+					spotifyShowURL = "https://open.spotify.com/show/5F2ppZb8gxJngLlO6wlIqX" // Fallback default
+					logger.Info("SPOTIFY_SHOW_URL not set in environment, using default value")
+				} else {
+					logger.Infof("Using Spotify show URL from environment: %s", spotifyShowURL)
+				}
 			}
+			logger.Infof("Spotify show URL: %s", spotifyShowURL)
 
 			if applePodcastShowURL == "" {
-				applePodcastShowURL = "https://podcasts.apple.com/us/podcast/momit-fm/id1589345170"
-				logger.Infof("Using default Apple Podcast show URL: %s", applePodcastShowURL)
+				applePodcastShowURL = os.Getenv("APPLE_PODCAST_URL")
+				if applePodcastShowURL == "" {
+					applePodcastShowURL = "https://podcasts.apple.com/us/podcast/momit-fm/id1589345170" // Fallback default
+					logger.Info("APPLE_PODCAST_URL not set in environment, using default value")
+				} else {
+					logger.Infof("Using Apple Podcast URL from environment: %s", applePodcastShowURL)
+				}
 			}
+			logger.Infof("Apple Podcast URL: %s", applePodcastShowURL)
 
 			// Initialize SNS service
 			snsService := services.NewSNSService(logger)
@@ -402,9 +420,9 @@ func Step4Cmd() *cobra.Command {
 	// Set flags
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Validate configuration without making external requests")
-	cmd.Flags().StringVar(&rssURL, "rss-url", "", "URL of the podcast RSS feed (default: https://rss.art19.com/momitfm)")
-	cmd.Flags().StringVar(&spotifyShowURL, "spotify-url", "", "URL of the Spotify show (default: https://open.spotify.com/show/5F2ppZb8gxJngLlO6wlIqX)")
-	cmd.Flags().StringVar(&applePodcastShowURL, "apple-url", "", "URL of the Apple Podcast show (default: https://podcasts.apple.com/us/podcast/momit-fm/id1589345170)")
+	cmd.Flags().StringVar(&rssURL, "rss-url", "", "URL of the podcast RSS feed (can also be set via RSS_FEED_URL environment variable)")
+	cmd.Flags().StringVar(&spotifyShowURL, "spotify-url", "", "URL of the Spotify show (can also be set via SPOTIFY_SHOW_URL environment variable)")
+	cmd.Flags().StringVar(&applePodcastShowURL, "apple-url", "", "URL of the Apple Podcast show (can also be set via APPLE_PODCAST_URL environment variable)")
 	cmd.Flags().StringVar(&outputFile, "output", "", "File to save the generated post text (optional)")
 
 	return cmd

--- a/internal/cli/steps.go
+++ b/internal/cli/steps.go
@@ -334,8 +334,8 @@ func Step4Cmd() *cobra.Command {
 			if rssURL == "" {
 				rssURL = os.Getenv("RSS_FEED_URL")
 				if rssURL == "" {
-					rssURL = "https://rss.art19.com/momitfm" // Fallback default
-					logger.Info("RSS_FEED_URL not set in environment, using default value")
+					logger.Error("RSS_FEED_URL not set in environment or command-line flag")
+					return fmt.Errorf("RSS feed URL is required. Set it with --rss-url flag or RSS_FEED_URL environment variable")
 				} else {
 					logger.Infof("Using RSS feed URL from environment: %s", rssURL)
 				}
@@ -345,8 +345,8 @@ func Step4Cmd() *cobra.Command {
 			if spotifyShowURL == "" {
 				spotifyShowURL = os.Getenv("SPOTIFY_SHOW_URL")
 				if spotifyShowURL == "" {
-					spotifyShowURL = "https://open.spotify.com/show/5F2ppZb8gxJngLlO6wlIqX" // Fallback default
-					logger.Info("SPOTIFY_SHOW_URL not set in environment, using default value")
+					logger.Error("SPOTIFY_SHOW_URL not set in environment or command-line flag")
+					return fmt.Errorf("Spotify show URL is required. Set it with --spotify-url flag or SPOTIFY_SHOW_URL environment variable")
 				} else {
 					logger.Infof("Using Spotify show URL from environment: %s", spotifyShowURL)
 				}
@@ -356,8 +356,8 @@ func Step4Cmd() *cobra.Command {
 			if applePodcastShowURL == "" {
 				applePodcastShowURL = os.Getenv("APPLE_PODCAST_URL")
 				if applePodcastShowURL == "" {
-					applePodcastShowURL = "https://podcasts.apple.com/us/podcast/momit-fm/id1589345170" // Fallback default
-					logger.Info("APPLE_PODCAST_URL not set in environment, using default value")
+					logger.Error("APPLE_PODCAST_URL not set in environment or command-line flag")
+					return fmt.Errorf("Apple Podcast URL is required. Set it with --apple-url flag or APPLE_PODCAST_URL environment variable")
 				} else {
 					logger.Infof("Using Apple Podcast URL from environment: %s", applePodcastShowURL)
 				}
@@ -420,9 +420,9 @@ func Step4Cmd() *cobra.Command {
 	// Set flags
 	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Validate configuration without making external requests")
-	cmd.Flags().StringVar(&rssURL, "rss-url", "", "URL of the podcast RSS feed (can also be set via RSS_FEED_URL environment variable)")
-	cmd.Flags().StringVar(&spotifyShowURL, "spotify-url", "", "URL of the Spotify show (can also be set via SPOTIFY_SHOW_URL environment variable)")
-	cmd.Flags().StringVar(&applePodcastShowURL, "apple-url", "", "URL of the Apple Podcast show (can also be set via APPLE_PODCAST_URL environment variable)")
+	cmd.Flags().StringVar(&rssURL, "rss-url", "", "URL of the podcast RSS feed (required, can also be set via RSS_FEED_URL environment variable)")
+	cmd.Flags().StringVar(&spotifyShowURL, "spotify-url", "", "URL of the Spotify show (required, can also be set via SPOTIFY_SHOW_URL environment variable)")
+	cmd.Flags().StringVar(&applePodcastShowURL, "apple-url", "", "URL of the Apple Podcast show (required, can also be set via APPLE_PODCAST_URL environment variable)")
 	cmd.Flags().StringVar(&outputFile, "output", "", "File to save the generated post text (optional)")
 
 	return cmd

--- a/services/sns_service.go
+++ b/services/sns_service.go
@@ -1,0 +1,193 @@
+package services
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// RSSFeed represents the structure of an RSS feed
+type RSSFeed struct {
+	XMLName xml.Name `xml:"rss"`
+	Channel struct {
+		Title       string `xml:"title"`
+		Description string `xml:"description"`
+		Items       []struct {
+			Title       string `xml:"title"`
+			Link        string `xml:"link"`
+			Description string `xml:"description"`
+			PubDate     string `xml:"pubDate"`
+			GUID        string `xml:"guid"`
+		} `xml:"item"`
+	} `xml:"channel"`
+}
+
+// SNSService handles generating text for social media posts
+type SNSService struct {
+	client *http.Client
+	logger *logrus.Logger
+}
+
+// NewSNSService creates a new SNSService instance
+func NewSNSService(logger *logrus.Logger) *SNSService {
+	return &SNSService{
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: logger,
+	}
+}
+
+// GetLatestEpisodeTitle fetches the latest episode title from the RSS feed
+func (s *SNSService) GetLatestEpisodeTitle(ctx context.Context, rssURL string) (string, error) {
+	s.logger.Debugf("Fetching latest episode title from RSS feed: %s", rssURL)
+	
+	feed, err := s.fetchRSSFeed(rssURL)
+	if err != nil {
+		return "", err
+	}
+	
+	if len(feed.Channel.Items) == 0 {
+		return "", fmt.Errorf("no episodes found in the RSS feed")
+	}
+	
+	latestEpisode := feed.Channel.Items[0]
+	s.logger.Debugf("Latest episode title: %s", latestEpisode.Title)
+	
+	return latestEpisode.Title, nil
+}
+
+// GetLatestSpotifyURL fetches the latest episode URL from Spotify
+func (s *SNSService) GetLatestSpotifyURL(ctx context.Context, showURL string) (string, error) {
+	s.logger.Debugf("Fetching latest episode URL from Spotify: %s", showURL)
+	
+	// Make a request to the Spotify show page
+	req, err := http.NewRequestWithContext(ctx, "GET", showURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request for Spotify: %w", err)
+	}
+	
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch Spotify show page: %w", err)
+	}
+	defer resp.Body.Close()
+	
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read Spotify response: %w", err)
+	}
+	
+	// Find the latest episode URL using regex
+	// This is a simplified approach and might need adjustment based on actual HTML structure
+	re := regexp.MustCompile(`https://open\.spotify\.com/episode/[a-zA-Z0-9]+`)
+	matches := re.FindStringSubmatch(string(body))
+	
+	if len(matches) == 0 {
+		// If we can't find the episode link, return the show URL as fallback
+		s.logger.Warn("Could not find latest episode URL from Spotify, using show URL as fallback")
+		return showURL, nil
+	}
+	
+	episodeURL := matches[0]
+	s.logger.Debugf("Latest Spotify episode URL: %s", episodeURL)
+	
+	return episodeURL, nil
+}
+
+// GetLatestApplePodcastURL fetches the latest episode URL from Apple Podcasts
+func (s *SNSService) GetLatestApplePodcastURL(ctx context.Context, showURL string) (string, error) {
+	s.logger.Debugf("Fetching latest episode URL from Apple Podcasts: %s", showURL)
+	
+	// Make a request to the Apple Podcasts show page
+	req, err := http.NewRequestWithContext(ctx, "GET", showURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request for Apple Podcasts: %w", err)
+	}
+	
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch Apple Podcasts show page: %w", err)
+	}
+	defer resp.Body.Close()
+	
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read Apple Podcasts response: %w", err)
+	}
+	
+	// Find the latest episode URL using regex
+	// This is a simplified approach and might need adjustment based on actual HTML structure
+	re := regexp.MustCompile(`https://podcasts\.apple\.com/us/podcast/[^"]+/id1589345170\?i=[0-9]+`)
+	matches := re.FindStringSubmatch(string(body))
+	
+	if len(matches) == 0 {
+		// If we can't find the episode link, return the show URL as fallback
+		s.logger.Warn("Could not find latest episode URL from Apple Podcasts, using show URL as fallback")
+		return showURL, nil
+	}
+	
+	episodeURL := matches[0]
+	s.logger.Debugf("Latest Apple Podcasts episode URL: %s", episodeURL)
+	
+	return episodeURL, nil
+}
+
+// CreateSNSPostText generates text for posting to social media platforms
+func (s *SNSService) CreateSNSPostText(title, spotifyURL, applePodcastURL string) string {
+	// Define the template parts
+	header := "IT企業で働くママによる子育て×Tech Podcast momit.fm を配信しました🎙 w/@m2vela"
+	divider := "—"
+	spotifyPrefix := "👇Spotify"
+	applePrefix := "👇Apple"
+	hashtags := "#momitfm #子育テック"
+	
+	// Build the template using strings.Join for better readability
+	parts := []string{
+		header,
+		divider,
+		title,
+		"",
+		spotifyPrefix,
+		spotifyURL,
+		"",
+		applePrefix,
+		applePodcastURL,
+		"",
+		hashtags,
+	}
+	
+	return strings.Join(parts, "\n")
+}
+
+// fetchRSSFeed fetches and parses an RSS feed from the given URL
+func (s *SNSService) fetchRSSFeed(url string) (*RSSFeed, error) {
+	resp, err := s.client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch RSS feed: %w", err)
+	}
+	defer resp.Body.Close()
+	
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch RSS feed, status code: %d", resp.StatusCode)
+	}
+	
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read RSS feed: %w", err)
+	}
+	
+	var feed RSSFeed
+	if err := xml.Unmarshal(body, &feed); err != nil {
+		return nil, fmt.Errorf("failed to parse RSS feed: %w", err)
+	}
+	
+	return &feed, nil
+}


### PR DESCRIPTION
## Description
This PR implements the step4 functionality for generating social media post text from podcast RSS feed data. The feature fetches the latest episode title from the RSS feed and creates a formatted post that includes links to the podcast on Spotify and Apple Podcasts.

## Changes
- Created a new `SNSService` for fetching data from RSS feeds and generating post text
- Implemented the `Step4Cmd` function to handle the social media post generation workflow
- Added environment variable support for configuring podcast URLs (RSS_FEED_URL, SPOTIFY_SHOW_URL, APPLE_PODCAST_URL)
- Updated the README with documentation for the new feature
- Added command-line flags for customizing the post generation

## Features
- Fetches the latest episode title from the podcast RSS feed
- Extracts episode URLs from Spotify and Apple Podcasts
- Generates a formatted post using a customizable template
- Provides options to save the post text to a file
- Supports configuration via environment variables or command-line flags

## Testing
- Successfully tested the feature with the momit.fm podcast
- Verified that it correctly fetches the latest episode information
- Confirmed that the generated post text follows the specified format

## Screenshots
N/A